### PR TITLE
(Fix #6) Fix for #6

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,10 @@ get '/:directory/:file' do |d, f|
   markdown("#{d}/#{f}")
 end
 
+get '/:directory/' do |d|
+  markdown("#{d}/index")
+end
+
 get '/:file' do |f|
   markdown("#{f}")
 end


### PR DESCRIPTION
```
get '/:directory/' do |d|
  markdown("#{d}/index")
end
```

を追加しました。
